### PR TITLE
Added load & reload commands to use nsfw cog after starring main repo

### DIFF
--- a/selfbot.py
+++ b/selfbot.py
@@ -66,6 +66,7 @@ class Selfbot(commands.Bot):
         self.add_command(self.ping)
         self.load_extensions()
         self.add_command(self.load)
+        self.add_command(self.reloadcog)
         self.load_community_extensions()
 
     def load_extensions(self, cogs=None, path='cogs.'):


### PR DESCRIPTION
Now nsfw cogs will not load automatically, but can be loaded manually via command using `load nsfw`

This is so to prevent people from unintentionally hitting help and showing everyone how lewd they really are deep down in the core of their hentai souls... amen :crossed_fingers: 